### PR TITLE
Round Linode transfer percentage

### DIFF
--- a/check_linode_transfer.pl
+++ b/check_linode_transfer.pl
@@ -95,6 +95,7 @@ if(! $data) {
 my ($used, $pool, $pct) = ($data->{TRANSFER_USED}, $data->{TRANSFER_POOL}, 0);
 
 $pct = ($used / $pool) * 100;
+$pct = sprintf("%.2f", $pct);
 
 if($pct >= $opt_c){
     $result = "CRITICAL";


### PR DESCRIPTION
Round the Linode transfer percentage to two decimals. This resolution should be enough: 0.01% represents less than five minutes of time in a month.